### PR TITLE
Cleaned up Protocol Methods

### DIFF
--- a/DossyText/DossyText.swift
+++ b/DossyText/DossyText.swift
@@ -8,10 +8,14 @@
 
 import UIKit
 
-@objc
 public protocol DossyTextLabelDelegate {
-    @objc optional func DossyTextLabel(_ label: DossyTextLabel, didFinishTypingText text: String)
-    @objc optional func didFinishBlinking(_ label: DossyTextLabel)
+    func dossyTextLabel(_ label: DossyTextLabel, didFinishTypingText text: String)
+    func dossyTextLabelDidFinishBlinking(_ label: DossyTextLabel)
+}
+
+extension DossyTextLabelDelegate {
+  func dossyTextLabel(_ label: DossyTextLabel, didFinishTypingText text: String) {}
+  func dossyTextLabelDidFinishBlinking(_ label: DossyTextLabel) {}
 }
 
 open class DossyTextLabel: UILabel {
@@ -76,7 +80,7 @@ open class DossyTextLabel: UILabel {
             if self.state == .blinking && repeats {
                 self.blink()
             } else {
-                self.delegate?.didFinishBlinking?(self)
+                self.delegate?.dossyTextLabelDidFinishBlinking(self)
             }
         }
     }
@@ -125,8 +129,8 @@ open class DossyTextLabel: UILabel {
         } else {
             state = .idle
         }
-        
-        delegate?.DossyTextLabel?(self, didFinishTypingText: mostRecentAddition)
+      
+        delegate?.dossyTextLabel(self, didFinishTypingText: mostRecentAddition)
     }
     
     // MARK: - Idling

--- a/DossyText/DossyText.swift
+++ b/DossyText/DossyText.swift
@@ -14,8 +14,8 @@ public protocol DossyTextLabelDelegate {
 }
 
 extension DossyTextLabelDelegate {
-  func dossyTextLabel(_ label: DossyTextLabel, didFinishTypingText text: String) {}
-  func dossyTextLabelDidFinishBlinking(_ label: DossyTextLabel) {}
+    func dossyTextLabel(_ label: DossyTextLabel, didFinishTypingText text: String) {}
+    func dossyTextLabelDidFinishBlinking(_ label: DossyTextLabel) {}
 }
 
 open class DossyTextLabel: UILabel {


### PR DESCRIPTION
Hey there, saw your post on reddit; this is a pretty coolio label.

Changes:
• Renamed protocol methods to be consistent
• Removed `@objc` keyword while still keeping the `optional` functionality (using extension)

Cheers!